### PR TITLE
Standardize Path Configuration in grid_world.py & grid_world_example.py

### DIFF
--- a/Code for grid world/python_version/examples/example_grid_world.py
+++ b/Code for grid world/python_version/examples/example_grid_world.py
@@ -1,6 +1,7 @@
 
 import sys
-sys.path.append("..")
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from src.grid_world import GridWorld
 import random
 import numpy as np

--- a/Code for grid world/python_version/src/grid_world.py
+++ b/Code for grid world/python_version/src/grid_world.py
@@ -1,7 +1,8 @@
 __credits__ = ["Intelligent Unmanned Systems Laboratory at Westlake University."]
 
-import sys    
-sys.path.append("..")         
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))) 
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches          


### PR DESCRIPTION
**Description**:
This PR addresses a critical path resolution issue affecting module imports in `grid_world.py` and `grid_world_example.py`:

**Root Cause**:
The original `sys.path.append("..")` statement added the literal string ".." to Python's search path, rather than resolving it to the actual parent directory. This caused module import failures in certain Python environments (e.g., Python 3.7.4) where relative path resolution is not automatically handled.

**Symptoms**:
-  "PYTHON_VERSION" directory was not being added to `sys.path`
- Import errors like `ModuleNotFoundError: No module named 'src'`
- Confirmed via `print(sys.path)` showing unresolved ".." in path list

**Solution**:
Replaced relative path appends with absolute path construction using:
```python
sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))